### PR TITLE
update function name in sample to execute

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -8,7 +8,7 @@ export class ExampleAction extends Hub.Action {
   supportedActionTypes = [Hub.ActionType.Query]
   params = []
 
-  async action(_request: Hub.ActionRequest) {
+  async execute(_request: Hub.ActionRequest) {
     // Implement your action here...
     return new Hub.ActionResponse()
   }


### PR DESCRIPTION
while trying to run this sample got 
```
2022-02-04T04:39:37.985049+00:00 app[web.1]: error: TypeError: this.execute is not a function
2022-02-04T04:39:37.985051+00:00 app[web.1]:     at ExampleAction.<anonymous> (/app/node_modules/looker-action-hub/lib/hub/action.js:90:29)
2022-02-04T04:39:37.985051+00:00 app[web.1]:     at Generator.next (<anonymous>)
2022-02-04T04:39:37.985052+00:00 app[web.1]:     at /app/node_modules/looker-action-hub/lib/hub/action.js:8:71
2022-02-04T04:39:37.985053+00:00 app[web.1]:     at new Promise (<anonymous>)
2022-02-04T04:39:37.985053+00:00 app[web.1]:     at __awaiter (/app/node_modules/looker-action-hub/lib/hub/action.js:4:12)
2022-02-04T04:39:37.985054+00:00 app[web.1]:     at ExampleAction.validateAndExecute (/app/node_modules/looker-action-hub/lib/hub/action.js:55:16)
2022-02-04T04:39:37.985054+00:00 app[web.1]:     at Server.<anonymous> (/app/node_modules/looker-action-hub/lib/server/server.js:72:49)
2022-02-04T04:39:37.985054+00:00 app[web.1]:     at Generator.next (<anonymous>)
2022-02-04T04:39:37.985055+00:00 app[web.1]:     at fulfilled (/app/node_modules/looker-action-hub/lib/server/server.js:5:58)
2022-02-04T04:39:37.985056+00:00 app[web.1]:     at processTicksAndRejections (internal/process/task_queues.js:93:5) url=/actions/dominos/execute, ip=::ffff:10.1.90.133, statusCode=500, instanceId=3a65d9a160022d8f02013436408b5ebf, webhookId=651215b813fa05b9477302960d529001
```

changing to `execute` fixed the issue